### PR TITLE
Before 1.2 update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: python linter
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+
+    - name: Install oelint-adv
+      run: |
+        python -m pip install oelint-adv
+
+    - name: Run linter
+      run: |
+        oelint-adv */*/*.bb */*/*.bbappend
+

--- a/.oelint.cfg
+++ b/.oelint.cfg
@@ -3,4 +3,3 @@ suppress=
   oelint.file.underscores
   oelint.var.licenseremotefile
 noinfo=True
-exit-zero=True

--- a/conf/distro/mapio.conf
+++ b/conf/distro/mapio.conf
@@ -4,7 +4,7 @@ require conf/distro/poky.conf
 # Distro description
 DISTRO = "mapio"
 DISTRO_NAME = "Mapio OS distribution"
-DISTRO_VERSION = "1.1"
+DISTRO_VERSION = "1.2-rc2"
 
 # Systemd
 DISTRO_FEATURES:append = " systemd"

--- a/conf/distro/mapio.conf
+++ b/conf/distro/mapio.conf
@@ -4,7 +4,7 @@ require conf/distro/poky.conf
 # Distro description
 DISTRO = "mapio"
 DISTRO_NAME = "Mapio OS distribution"
-DISTRO_VERSION = "1.0"
+DISTRO_VERSION = "1.1"
 
 # Systemd
 DISTRO_FEATURES:append = " systemd"

--- a/recipes-core/bundles/files/hook-with-kernel.sh
+++ b/recipes-core/bundles/files/hook-with-kernel.sh
@@ -15,6 +15,10 @@ case "$1" in
                         cp /tmp/wpa_supplicant-wlan0.conf "$RAUC_SLOT_MOUNT_POINT"/etc/wpa_supplicant/
                         ln -s "$RAUC_SLOT_MOUNT_POINT"/lib/systemd/system/wpa_supplicant@.service "$RAUC_SLOT_MOUNT_POINT"/etc/systemd/system/multi-user.target.wants/wpa_supplicant@wlan0.service
                 fi
+                # Update kernel, devicetree and bootscript
+                cp "$RAUC_BUNDLE_MOUNT_POINT"/Image /boot/Image
+                cp "$RAUC_BUNDLE_MOUNT_POINT"/bcm2711-rpi-cm4-io.dtb /boot/bcm2711-rpi-cm4-io.dtb
+                cp "$RAUC_BUNDLE_MOUNT_POINT"/boot.scr /boot/boot.scr
                 ;;
         *)
                 exit 1

--- a/recipes-core/bundles/files/hook.sh
+++ b/recipes-core/bundles/files/hook.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+case "$1" in
+        slot-post-install)
+                # Update kernel, devicetree and bootscript
+                cp "$RAUC_BUNDLE_MOUNT_POINT"/Image /boot/Image
+                cp "$RAUC_BUNDLE_MOUNT_POINT"/bcm2711-rpi-cm4-io.dtb /boot/bcm2711-rpi-cm4-io.dtb
+                cp "$RAUC_BUNDLE_MOUNT_POINT"/boot.scr /boot/boot.scr
+                ;;
+        *)
+                exit 1
+                ;;
+esac
+
+exit 0

--- a/recipes-core/bundles/mapio-bundle-image-with-kernel.bb
+++ b/recipes-core/bundles/mapio-bundle-image-with-kernel.bb
@@ -1,0 +1,26 @@
+# nooelint: oelint.var.mandatoryvar
+SUMMARY = "MAPIO rauc bunlde base"
+DESCRIPTION = "Configure rauc bundle to update mapio image"
+HOMEPAGE = "https://github.com/pcurt/meta-mapio-distro"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+
+SRC_URI:append = " file://hook.sh"
+
+inherit bundle
+
+RAUC_BUNDLE_COMPATIBLE ?= "mapio-image"
+
+RAUC_BUNDLE_SLOTS ?= "rootfs"
+
+# nooelint: oelint.vars.specific
+RAUC_SLOT_rootfs ?= "mapio-image"
+
+RAUC_KEY_FILE = "${SECRET_PATH}/development-1.key.pem"
+RAUC_CERT_FILE = "${SECRET_PATH}/development-1.cert.pem"
+
+RAUC_BUNDLE_EXTRA_FILES += "Image"
+RAUC_BUNDLE_EXTRA_FILES += "bcm2711-rpi-cm4-io.dtb"
+RAUC_BUNDLE_EXTRA_FILES += "boot.scr"
+RAUC_BUNDLE_HOOKS[file] = "hook.sh"
+RAUC_SLOT_rootfs[hooks] = "post-install"

--- a/recipes-core/bundles/mapio-bundle-image-with-kernel.bb
+++ b/recipes-core/bundles/mapio-bundle-image-with-kernel.bb
@@ -5,7 +5,7 @@ HOMEPAGE = "https://github.com/pcurt/meta-mapio-distro"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 
-SRC_URI:append = " file://hook.sh"
+SRC_URI:append = " file://hook-with-kernel.sh"
 
 inherit bundle
 
@@ -22,5 +22,5 @@ RAUC_CERT_FILE = "${SECRET_PATH}/development-1.cert.pem"
 RAUC_BUNDLE_EXTRA_FILES += "Image"
 RAUC_BUNDLE_EXTRA_FILES += "bcm2711-rpi-cm4-io.dtb"
 RAUC_BUNDLE_EXTRA_FILES += "boot.scr"
-RAUC_BUNDLE_HOOKS[file] = "hook.sh"
-RAUC_SLOT_rootfs[hooks] = "post-install"
+RAUC_BUNDLE_HOOKS[file] = "hook-with-kernel.sh"
+RAUC_SLOT_rootfs[hooks] = "pre-install;post-install"

--- a/recipes-core/bundles/mapio-bundle-image.bb
+++ b/recipes-core/bundles/mapio-bundle-image.bb
@@ -2,8 +2,8 @@
 SUMMARY = "MAPIO rauc bunlde base"
 DESCRIPTION = "Configure rauc bundle to update mapio image"
 HOMEPAGE = "https://github.com/pcurt/meta-mapio-distro"
-LICENSE = "GPL-2.0"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 
 inherit bundle
 

--- a/recipes-core/bundles/mapio-bundle-image.bb
+++ b/recipes-core/bundles/mapio-bundle-image.bb
@@ -5,6 +5,8 @@ HOMEPAGE = "https://github.com/pcurt/meta-mapio-distro"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 
+SRC_URI:append = " file://hook.sh"
+
 inherit bundle
 
 RAUC_BUNDLE_COMPATIBLE ?= "mapio-image"
@@ -17,3 +19,5 @@ RAUC_SLOT_rootfs ?= "mapio-image"
 RAUC_KEY_FILE = "${SECRET_PATH}/development-1.key.pem"
 RAUC_CERT_FILE = "${SECRET_PATH}/development-1.cert.pem"
 
+RAUC_BUNDLE_HOOKS[file] = "hook.sh"
+RAUC_SLOT_rootfs[hooks] = "pre-install;post-install"

--- a/recipes-httpd/nginx/files/nginx.conf
+++ b/recipes-httpd/nginx/files/nginx.conf
@@ -1,0 +1,33 @@
+user www-data;
+worker_processes 1;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+events {
+  worker_connections 1024;
+}
+http {
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+  log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+  '$status $body_bytes_sent "$http_referer" '
+  '"$http_user_agent" "$http_x_forwarded_for"';
+  access_log /var/log/nginx/access.log main;
+  sendfile on;
+  keepalive_timeout 65;
+  server {
+    listen 80;
+    server_name localhost;
+    location ~* \.(js|jpg|png|css|fonts)$ {
+      root /var/www/webserver/dist;
+    }
+    location / {
+      root /var/www/webserver/dist;
+      index /index.html;
+      try_files $uri $uri/ /index.html;
+    }
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+      root /usr/share/nginx/html;
+    }
+  }
+}

--- a/recipes-httpd/nginx/files/nginx.service
+++ b/recipes-httpd/nginx/files/nginx.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=The NGINX HTTP and reverse proxy server
+After=syslog.target network.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=forking
+PIDFile=/var/run/nginx.pid
+ExecStart=/usr/sbin/nginx -c /etc/nginx/nginx.conf
+ExecReload=/usr/sbin/nginx -s reload
+ExecStop=/bin/kill -s QUIT $MAINPID
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-httpd/nginx/nginx_%.bbappend
+++ b/recipes-httpd/nginx/nginx_%.bbappend
@@ -1,0 +1,13 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI:append = " \
+    file://nginx.conf \
+    file://nginx.service \
+"
+
+do_install:append () {
+    install -d ${D}${sysconfdir}/nginx/
+    install -m 0644 ${WORKDIR}/nginx.conf ${D}/${sysconfdir}/nginx/nginx.conf
+}
+
+FILES:${PN} += "${sysconfdir}/nginx/nginx.conf"

--- a/recipes-mapio/images/mapio-image.bb
+++ b/recipes-mapio/images/mapio-image.bb
@@ -55,4 +55,6 @@ IMAGE_INSTALL += "\
     mapio-display \
     mapio-gpio-ha \
     mapio-setup-wizard \
+    python3-pyserial \
+    python3-intelhex \
 "

--- a/recipes-mapio/images/mapio-image.bb
+++ b/recipes-mapio/images/mapio-image.bb
@@ -61,8 +61,7 @@ IMAGE_INSTALL += "\
     mapio-docker-compose \
     mapio-display \
     mapio-gpio-ha \
-    python3-pyserial \
-    python3-intelhex \
+    mapio-tools \
     mapio-webserver-back \
     mapio-webserver-front \
 "

--- a/recipes-mapio/images/mapio-image.bb
+++ b/recipes-mapio/images/mapio-image.bb
@@ -1,8 +1,8 @@
 SUMMARY = "MAPIO image base"
 DESCRIPTION = "Install all needed applicative tools for MAPIO gateway"
 HOMEPAGE = "https://github.com/pcurt/meta-mapio-distro"
-LICENSE = "GPL-2.0"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 
 inherit core-image extrausers
 

--- a/recipes-mapio/images/mapio-image.bb
+++ b/recipes-mapio/images/mapio-image.bb
@@ -50,6 +50,9 @@ IMAGE_INSTALL += "\
     bluez5 \
     iperf3 \
     i2c-tools \
+    systemd-analyze \
+    screen \
+    zram \
 "
 
 ### MAPIO APP ###

--- a/recipes-mapio/images/mapio-image.bb
+++ b/recipes-mapio/images/mapio-image.bb
@@ -4,7 +4,11 @@ HOMEPAGE = "https://github.com/pcurt/meta-mapio-distro"
 LICENSE = "GPL-2.0"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 
-inherit core-image
+inherit core-image extrausers
+
+EXTRA_USERS_PARAMS = "\
+    usermod -p '${PASSWD_ROOT}' root; \
+    "
 
 IMAGE_INSTALL:append = " tzdata"
 

--- a/recipes-mapio/images/mapio-image.bb
+++ b/recipes-mapio/images/mapio-image.bb
@@ -61,7 +61,8 @@ IMAGE_INSTALL += "\
     mapio-docker-compose \
     mapio-display \
     mapio-gpio-ha \
-    mapio-setup-wizard \
     python3-pyserial \
     python3-intelhex \
+    mapio-webserver-back \
+    mapio-webserver-front \
 "


### PR DESCRIPTION
This PR introduces the following features:
- tools to flash zigbee modules
- tools to test a MAPIO board
- Use a new web server to configure MAPIO OS
- Create RAUC bundle that can update the kernel
- Backup WIFI credentials during OTA update